### PR TITLE
Potential fix for code scanning alert no. 1: Overly permissive regular expression range

### DIFF
--- a/test/fixtures/clean-snapshot.js
+++ b/test/fixtures/clean-snapshot.js
@@ -7,7 +7,7 @@ const cleanNewlines = (s) => s.replace(/\r\n/g, '\n')
 // ideally this could be avoided but its easier to just
 // run this command inside cleanSnapshot
 const normalizePath = (str) => cleanNewlines(str)
-  .replace(/[A-z]:\\/g, '\\') // turn windows roots to posix ones
+  .replace(/[A-Z]:\\/g, '\\') // turn windows roots to posix ones
   .replace(/\\+/g, '/') // replace \ with /
 
 const pathRegex = (p) => new RegExp(normalizePath(p), 'gi')


### PR DESCRIPTION
Potential fix for [https://github.com/bbbrey98/cli/security/code-scanning/1](https://github.com/bbbrey98/cli/security/code-scanning/1)

To fix the problem, we need to update the regular expression on line 10 to correctly match only uppercase drive letters. The correct range for this purpose is `A-Z`. This change ensures that only valid drive letters are matched, avoiding any unintended matches with other characters.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
